### PR TITLE
feat: add medical shift recurrence support with cascade deletion

### DIFF
--- a/med_system_app/lib/features/medical_shifts/model/medical_shift.model.dart
+++ b/med_system_app/lib/features/medical_shifts/model/medical_shift.model.dart
@@ -12,6 +12,7 @@ class MedicalShiftModel {
   String? shift;
   String? date;
   String? hour;
+  int? medicalShiftRecurrenceId;
 
   MedicalShiftModel(
       {this.id,
@@ -24,7 +25,8 @@ class MedicalShiftModel {
       this.title,
       this.shift,
       this.date,
-      this.hour});
+      this.hour,
+      this.medicalShiftRecurrenceId});
 
   MedicalShiftModel.fromJson(Map<String, dynamic> json) {
     id = json['id'];
@@ -38,6 +40,7 @@ class MedicalShiftModel {
     shift = json['shift'];
     date = json['date'];
     hour = json['hour'];
+    medicalShiftRecurrenceId = json['medical_shift_recurrence_id'];
   }
 
   Map<String, dynamic> toJson() {
@@ -52,6 +55,7 @@ class MedicalShiftModel {
     data['title'] = title;
     data['shift'] = shift;
     data['hour'] = hour;
+    data['medical_shift_recurrence_id'] = medicalShiftRecurrenceId;
     return data;
   }
 
@@ -66,7 +70,8 @@ class MedicalShiftModel {
       String? title,
       String? shift,
       String? date,
-      String? hour}) {
+      String? hour,
+      int? medicalShiftRecurrenceId}) {
     return MedicalShiftModel(
         id: id ?? this.id,
         hospitalName: hospitalName ?? this.hospitalName,
@@ -78,7 +83,9 @@ class MedicalShiftModel {
         title: title ?? this.title,
         shift: shift ?? this.shift,
         date: date ?? this.date,
-        hour: hour ?? this.hour);
+        hour: hour ?? this.hour,
+        medicalShiftRecurrenceId:
+            medicalShiftRecurrenceId ?? this.medicalShiftRecurrenceId);
   }
 
   Icon get shiftIcon {

--- a/med_system_app/lib/features/medical_shifts/pages/medical_shifts_page.dart
+++ b/med_system_app/lib/features/medical_shifts/pages/medical_shifts_page.dart
@@ -298,20 +298,27 @@ class _MedicalShiftsPageState extends State<MedicalShiftsPage> {
                                             icon: Icons.delete,
                                             label: 'Deletar',
                                             onPressed: (context) {
+                                              final hasRecurrence =
+                                                  medicalShiftModel
+                                                          .medicalShiftRecurrenceId !=
+                                                      null;
                                               showAlert(
                                                 context: context,
                                                 title: 'Excluir Plantão',
-                                                content:
-                                                    'Tem certeza que deseja excluir este plantão?',
+                                                content: hasRecurrence
+                                                    ? 'Este plantão faz parte de uma recorrência. Tem certeza que deseja excluir este plantão e sua recorrência?'
+                                                    : 'Tem certeza que deseja excluir este plantão?',
                                                 textYes: 'Sim',
                                                 textNo: 'Não',
                                                 onPressedConfirm: () {
                                                   medicalShiftStore
                                                       .deleteMedicalShift(
-                                                          medicalShiftModel
-                                                                  .id ??
-                                                              0,
-                                                          index);
+                                                    medicalShiftModel.id ?? 0,
+                                                    index,
+                                                    medicalShiftRecurrenceId:
+                                                        medicalShiftModel
+                                                            .medicalShiftRecurrenceId,
+                                                  );
                                                 },
                                                 onPressedCancel: () {},
                                               );

--- a/med_system_app/lib/features/medical_shifts/repository/medical_shift_repository.dart
+++ b/med_system_app/lib/features/medical_shifts/repository/medical_shift_repository.dart
@@ -11,8 +11,11 @@ import 'package:distrito_medico/features/medical_shifts/model/medical_shift.mode
 import 'package:distrito_medico/features/medical_shifts/model/medical_shift_list.model.dart';
 
 import '../model/amount_suggestions.model.dart';
+import '../../medical_shift_recurrences/repository/medical_shift_recurrence_repository.dart';
 
 class MedicalShiftRepository {
+  final MedicalShiftRecurrenceRepository _recurrenceRepository =
+      MedicalShiftRecurrenceRepository();
   Future<Result<MedicalShiftList?>?> getMedicalShiftsByFilters(
       {int? page,
       int? perPage,
@@ -188,9 +191,14 @@ class MedicalShiftRepository {
     return null;
   }
 
-  Future<Result<MedicalShiftModel>?> deleteMedicalShift(
-      int medicalShiftId) async {
+  Future<Result<MedicalShiftModel>?> deleteMedicalShift(int medicalShiftId,
+      {int? medicalShiftRecurrenceId}) async {
     try {
+      if (medicalShiftRecurrenceId != null) {
+        await _recurrenceRepository
+            .deleteMedicalShiftRecurrence(medicalShiftRecurrenceId);
+      }
+
       final response =
           await medicalShiftService.deleteEventMedicalShifts(medicalShiftId);
 

--- a/med_system_app/lib/features/medical_shifts/store/medical_shift.store.dart
+++ b/med_system_app/lib/features/medical_shifts/store/medical_shift.store.dart
@@ -240,10 +240,12 @@ abstract class _MedicalShiftStoreBase with Store {
   }
 
   @action
-  deleteMedicalShift(int medicalShiftId, index) async {
+  deleteMedicalShift(int medicalShiftId, index,
+      {int? medicalShiftRecurrenceId}) async {
     deleteState = DeleteMedicalShiftState.loading;
-    var deleteResult =
-        await _medicalShiftRepository.deleteMedicalShift(medicalShiftId);
+    var deleteResult = await _medicalShiftRepository.deleteMedicalShift(
+        medicalShiftId,
+        medicalShiftRecurrenceId: medicalShiftRecurrenceId);
     deleteResult?.when(success: (shift) {
       medicalShiftList.removeAt(index);
       deleteState = DeleteMedicalShiftState.success;

--- a/med_system_app/lib/features/medical_shifts/store/medical_shift.store.g.dart
+++ b/med_system_app/lib/features/medical_shifts/store/medical_shift.store.g.dart
@@ -275,9 +275,11 @@ mixin _$MedicalShiftStore on _MedicalShiftStoreBase, Store {
       context: context);
 
   @override
-  Future deleteMedicalShift(int medicalShiftId, dynamic index) {
-    return _$deleteMedicalShiftAsyncAction
-        .run(() => super.deleteMedicalShift(medicalShiftId, index));
+  Future deleteMedicalShift(int medicalShiftId, dynamic index,
+      {int? medicalShiftRecurrenceId}) {
+    return _$deleteMedicalShiftAsyncAction.run(() => super.deleteMedicalShift(
+        medicalShiftId, index,
+        medicalShiftRecurrenceId: medicalShiftRecurrenceId));
   }
 
   late final _$editPaymentMedicalShiftAsyncAction = AsyncAction(


### PR DESCRIPTION
- Add medical_shift_recurrence_id field to MedicalShiftModel
- Implement cascade deletion of recurrence when deleting medical shift
- Update delete confirmation dialog to warn about recurring shifts
- Integrate MedicalShiftRecurrenceRepository in deletion flow